### PR TITLE
Dockerfile: `apk add git` to resolve `exec: "git": executable file not found in $PATH`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Build Geth in a stock Go builder container
 FROM golang:1.10-alpine as builder
 
-RUN apk add --no-cache make gcc musl-dev linux-headers
+RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 ADD . /genom
 RUN cd /genom && make geth


### PR DESCRIPTION
Add `git`, a missing dependency needed during the genom geth build:

```$ docker build -f Dockerfile -t genom:`git rev-parse --short HEAD` .
Sending build context to Docker daemon  52.48MB
Step 1/9 : FROM golang:1.10-alpine as builder
1.10-alpine: Pulling from library/golang
4fe2ade4980c: Already exists 
2e793f0ebe8a: Pull complete 
77995fba1918: Pull complete 
2d13b0280926: Pull complete 
0934a9e51936: Pull complete 
Digest: sha256:285cf869f678d6f3be1dc6baf8336c764bc1b5cfaf5c54493ab796eccb614216
Status: Downloaded newer image for golang:1.10-alpine
 ---> 2f577258bd10
Step 2/9 : RUN apk add --no-cache make gcc musl-dev linux-headers
 ---> Running in 4f26e08d01ff
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/community/x86_64/APKINDEX.tar.gz
(1/14) Installing binutils (2.30-r5)
(2/14) Installing gmp (6.1.2-r1)
(3/14) Installing isl (0.18-r0)
(4/14) Installing libgomp (6.4.0-r9)
(5/14) Installing libatomic (6.4.0-r9)
(6/14) Installing pkgconf (1.5.3-r0)
(7/14) Installing libgcc (6.4.0-r9)
(8/14) Installing mpfr3 (3.1.5-r1)
(9/14) Installing mpc1 (1.0.3-r1)
(10/14) Installing libstdc++ (6.4.0-r9)
(11/14) Installing gcc (6.4.0-r9)
(12/14) Installing linux-headers (4.4.6-r2)
(13/14) Installing make (4.2.1-r2)
(14/14) Installing musl-dev (1.1.19-r10)
Executing busybox-1.28.4-r1.trigger
OK: 105 MiB in 28 packages
Removing intermediate container 4f26e08d01ff
 ---> 8c300d970afb
Step 3/9 : ADD . /genom
 ---> 3729a07b4e81
Step 4/9 : RUN cd /genom && make geth
 ---> Running in 0fb24d279ace
build/env.sh go run build/ci.go install ./cmd/geth
util.go:87: git tag -l --points-at HEAD: exec: "git": executable file not found in $PATH
exit status 1
make: *** [Makefile:15: geth] Error 1
The command '/bin/sh -c cd /genom && make geth' returned a non-zero code: 2
```